### PR TITLE
Fix tests

### DIFF
--- a/test/HttpCacheListenerTest.php
+++ b/test/HttpCacheListenerTest.php
@@ -463,7 +463,7 @@ class HttpCacheListenerTest extends TestCase
                     'override' => true,
                     'value'    => 'max-age=86400, must-revalidate, public',
                 ]],
-                ['Cache-Control' => 'max-age=86400, must-revalidate, public, no-cache'],
+                ['Cache-Control' => 'max-age=86400, must-revalidate, no-cache, public'],
                 ['Cache-Control' => 'max-age=86400, must-revalidate, public'],
             ],
             [
@@ -471,8 +471,8 @@ class HttpCacheListenerTest extends TestCase
                     'override' => false,
                     'value'    => 'max-age=86400, must-revalidate, public',
                 ]],
-                ['Cache-Control' => 'max-age=86400, must-revalidate, public, no-cache'],
-                ['Cache-Control' => 'max-age=86400, must-revalidate, public, no-cache'],
+                ['Cache-Control' => 'max-age=86400, must-revalidate, no-cache, public'],
+                ['Cache-Control' => 'max-age=86400, must-revalidate, no-cache, public'],
             ],
         ];
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fixes test by altering data provider

Issue was caused by laminas-http `CacheControl::fromString` ordering directives alphabetically, whereas `Headers::addHeaderLine` does not. AFAIK the order of directives does not matter, so I just ensured the directives are pre-sorted in the data provider
